### PR TITLE
[nix/sv-se] Update Further reading link for consistency

### DIFF
--- a/sv-se/nix-sv.html.markdown
+++ b/sv-se/nix-sv.html.markdown
@@ -364,5 +364,5 @@ with builtins; [
 * [James Fisher - Nix by example - Part 1: The Nix expression language]
   (https://medium.com/@MrJamesFisher/nix-by-example-a0063a1a4c55)
 
-* [Susan Potter - Nix Cookbook - Nix By Example]
-  (http://funops.co/nix-cookbook/nix-by-example/)
+* [Rommel Martinez - A Gentle Introduction to the Nix Family]
+  (https://web.archive.org/web/20210121042658/https://ebzzry.io/en/nix/#nix)


### PR DESCRIPTION
Replace dead `Susan Potter` link and replace with `Rommel Martinez` reference from `[nix/en]`.
Was unable to find archived version of Potter link. Using Nix Manual, Fisher example, and Martinez
intro as the three `Further Reading` references across translations.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
